### PR TITLE
fix: remove including bitcode

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,7 +54,6 @@ platform :ios do
       export_method: ENV['EXPORT_METHOD'],
       export_team_id: ENV['TEAM_ID'],
       silent: true,
-      include_bitcode: true,
       export_options: ENV['IOS_APP_ID'] != nil ? {
         provisioningProfiles: {
           "#{ENV['IOS_APP_ID']}" => "match AppStore #{ENV['IOS_APP_ID']}",


### PR DESCRIPTION
Fix #17 

The issue was with Xcode 14 and deprecation of bitcode.

Tested on our own private repository and the forked of this one.

Sources: 
- https://monicagranbois.com/blog/xcode/bitcode-is-imbalanced/
- https://stackoverflow.com/questions/37605085/itc-apps-assetvalidation-bitcode-imbalance-error-error-message